### PR TITLE
Add support for classes (React Components) as children

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -213,8 +213,8 @@ export default React.createClass({
       ...this.state,
       ...this.getAPI()
     }
-    const { component, children, ...rest } = props
-    const resolvedChild = typeof children === 'function' ? children(rest) : children
+    const { component, children: Child, ...rest } = props
+    const resolvedChild = typeof children === 'function' ? <Child {...rest} /> : Child
     const RootEl = component
     if (!RootEl) {
       return resolvedChild

--- a/src/form.js
+++ b/src/form.js
@@ -214,7 +214,7 @@ export default React.createClass({
       ...this.getAPI()
     }
     const { component, children, ...rest } = props
-    const resolvedChild = _.normalizeComponent(children, rest)
+    const resolvedChild = _.normalizeComponent(children, formAPI)
     const RootEl = component
     if (!RootEl) {
       return resolvedChild

--- a/src/form.js
+++ b/src/form.js
@@ -214,7 +214,7 @@ export default React.createClass({
       ...this.getAPI()
     }
     const { component, children, ...rest } = props
-    const resolvedChild = _.normalizeComponent(children, rest);
+    const resolvedChild = _.normalizeComponent(children, rest)
     const RootEl = component
     if (!RootEl) {
       return resolvedChild

--- a/src/form.js
+++ b/src/form.js
@@ -213,8 +213,8 @@ export default React.createClass({
       ...this.state,
       ...this.getAPI()
     }
-    const { component, children: Child, ...rest } = props
-    const resolvedChild = typeof children === 'function' ? <Child {...rest} /> : Child
+    const { component, children, ...rest } = props
+    const resolvedChild = _.normalizeComponent(children, formAPI)
     const RootEl = component
     if (!RootEl) {
       return resolvedChild

--- a/src/form.js
+++ b/src/form.js
@@ -214,7 +214,7 @@ export default React.createClass({
       ...this.getAPI()
     }
     const { component, children, ...rest } = props
-    const resolvedChild = _.normalizeComponent(children, formAPI)
+    const resolvedChild = _.normalizeComponent(children, rest)
     const RootEl = component
     if (!RootEl) {
       return resolvedChild

--- a/src/form.js
+++ b/src/form.js
@@ -213,8 +213,8 @@ export default React.createClass({
       ...this.state,
       ...this.getAPI()
     }
-    const { component, children, ...rest } = props
-    const resolvedChild = _.normalizeComponent(children, formAPI)
+    const { component, children: Child, ...rest } = props
+    const resolvedChild = typeof children === 'function' ? <Child {...rest} /> : Child
     const RootEl = component
     if (!RootEl) {
       return resolvedChild

--- a/src/form.js
+++ b/src/form.js
@@ -214,7 +214,7 @@ export default React.createClass({
       ...this.getAPI()
     }
     const { component, children: Child, ...rest } = props
-    const resolvedChild = typeof children === 'function' ? <Child {...rest} /> : Child
+    const resolvedChild = typeof Child === 'function' ? <Child {...rest} /> : Child
     const RootEl = component
     if (!RootEl) {
       return resolvedChild

--- a/src/form.js
+++ b/src/form.js
@@ -213,8 +213,8 @@ export default React.createClass({
       ...this.state,
       ...this.getAPI()
     }
-    const { component, children: Child, ...rest } = props
-    const resolvedChild = typeof Child === 'function' ? <Child {...rest} /> : Child
+    const { component, children, ...rest } = props
+    const resolvedChild = _.normalizeComponent(children, rest);
     const RootEl = component
     if (!RootEl) {
       return resolvedChild

--- a/src/formField.js
+++ b/src/formField.js
@@ -2,9 +2,10 @@ import React from 'react'
 //
 import _ from './utils'
 
-export default function FormField ({field, children}, context) {
+export default function FormField ({field, children: Child}, context) {
   const bind = (cb, ...args) => (...args2) => cb(...args, ...args2)
-  return children(field ? _.mapValues(context.formAPI, d => bind(d, field)) : context.formAPI)
+  const formAPI = field ? _.mapValues(context.formAPI, d => bind(d, field)) : context.formAPI
+  return <Child {...formAPI} />
 }
 FormField.contextTypes = {
   formAPI: React.PropTypes.object

--- a/src/formField.js
+++ b/src/formField.js
@@ -2,10 +2,10 @@ import React from 'react'
 //
 import _ from './utils'
 
-export default function FormField ({field, children: Child}, context) {
+export default function FormField ({field, children}, context) {
   const bind = (cb, ...args) => (...args2) => cb(...args, ...args2)
   const formAPI = field ? _.mapValues(context.formAPI, d => bind(d, field)) : context.formAPI
-  return <Child {...formAPI} />
+  return _.normalizeComponent(children, formAPI);
 }
 FormField.contextTypes = {
   formAPI: React.PropTypes.object

--- a/src/formField.js
+++ b/src/formField.js
@@ -2,10 +2,10 @@ import React from 'react'
 //
 import _ from './utils'
 
-export default function FormField ({field, children}, context) {
+export default function FormField ({field, children, ...rest}, context) {
   const bind = (cb, ...args) => (...args2) => cb(...args, ...args2)
   const formAPI = field ? _.mapValues(context.formAPI, d => bind(d, field)) : context.formAPI
-  return _.normalizeComponent(children, formAPI)
+  return _.normalizeComponent(children, { ...formAPI, ...rest })
 }
 FormField.contextTypes = {
   formAPI: React.PropTypes.object

--- a/src/formField.js
+++ b/src/formField.js
@@ -5,7 +5,7 @@ import _ from './utils'
 export default function FormField ({field, children}, context) {
   const bind = (cb, ...args) => (...args2) => cb(...args, ...args2)
   const formAPI = field ? _.mapValues(context.formAPI, d => bind(d, field)) : context.formAPI
-  return _.normalizeComponent(children, formAPI);
+  return _.normalizeComponent(children, formAPI)
 }
 FormField.contextTypes = {
   formAPI: React.PropTypes.object

--- a/src/formField.js
+++ b/src/formField.js
@@ -2,10 +2,10 @@ import React from 'react'
 //
 import _ from './utils'
 
-export default function FormField ({field, children}, context) {
+export default function FormField ({field, children: Child}, context) {
   const bind = (cb, ...args) => (...args2) => cb(...args, ...args2)
   const formAPI = field ? _.mapValues(context.formAPI, d => bind(d, field)) : context.formAPI
-  return _.normalizeComponent(children, formAPI)
+  return <Child {...formAPI} />
 }
 FormField.contextTypes = {
   formAPI: React.PropTypes.object

--- a/src/formField.js
+++ b/src/formField.js
@@ -2,10 +2,10 @@ import React from 'react'
 //
 import _ from './utils'
 
-export default function FormField ({field, children: Child}, context) {
+export default function FormField ({field, children}, context) {
   const bind = (cb, ...args) => (...args2) => cb(...args, ...args2)
   const formAPI = field ? _.mapValues(context.formAPI, d => bind(d, field)) : context.formAPI
-  return <Child {...formAPI} />
+  return _.normalizeComponent(children, formAPI)
 }
 FormField.contextTypes = {
   formAPI: React.PropTypes.object

--- a/src/formInput.js
+++ b/src/formInput.js
@@ -4,7 +4,7 @@ import classnames from 'classnames'
 import FormField from './formField'
 import FormError from './formError'
 
-export default function FormInput ({ field, showErrors = true, errorBefore, isForm, className, children }) {
+export default function FormInput ({ field, showErrors = true, errorBefore, isForm, className, children: Child }) {
   return (
     <FormField field={field}>
       {({ ...api }) => {
@@ -18,9 +18,7 @@ export default function FormInput ({ field, showErrors = true, errorBefore, isFo
             {errorBefore && showAnyErrors && (
               <FormError field={field} />
             )}
-            {children({
-              ...api
-            })}
+            <Child {...api} />
             {!errorBefore && showAnyErrors && (
               <FormError field={field} />
             )}

--- a/src/formInput.js
+++ b/src/formInput.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import classnames from 'classnames'
+import _ from './utils'
 
 import FormField from './formField'
 import FormError from './formError'

--- a/src/formInput.js
+++ b/src/formInput.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import classnames from 'classnames'
-import _ from './utils'
 
 import FormField from './formField'
 import FormError from './formError'

--- a/src/formInput.js
+++ b/src/formInput.js
@@ -19,7 +19,7 @@ export default function FormInput ({ field, showErrors = true, errorBefore, isFo
             {errorBefore && showAnyErrors && (
               <FormError field={field} />
             )}
-              {_.normalizeComponent(children, api)}
+            {_.normalizeComponent(children, api)}
             {!errorBefore && showAnyErrors && (
               <FormError field={field} />
             )}

--- a/src/formInput.js
+++ b/src/formInput.js
@@ -1,10 +1,11 @@
 import React from 'react'
 import classnames from 'classnames'
 
+import _ from './utils'
 import FormField from './formField'
 import FormError from './formError'
 
-export default function FormInput ({ field, showErrors = true, errorBefore, isForm, className, children: Child }) {
+export default function FormInput ({ field, showErrors = true, errorBefore, isForm, className, children }) {
   return (
     <FormField field={field}>
       {({ ...api }) => {
@@ -18,7 +19,7 @@ export default function FormInput ({ field, showErrors = true, errorBefore, isFo
             {errorBefore && showAnyErrors && (
               <FormError field={field} />
             )}
-            <Child {...api} />
+              {_.normalizeComponent(children, api)}
             {!errorBefore && showAnyErrors && (
               <FormError field={field} />
             )}

--- a/src/formInput.js
+++ b/src/formInput.js
@@ -5,7 +5,7 @@ import _ from './utils'
 import FormField from './formField'
 import FormError from './formError'
 
-export default function FormInput ({ field, showErrors = true, errorBefore, isForm, className, children }) {
+export default function FormInput ({ field, showErrors = true, errorBefore, isForm, className, children, ...rest }) {
   return (
     <FormField field={field}>
       {({ ...api }) => {
@@ -19,7 +19,7 @@ export default function FormInput ({ field, showErrors = true, errorBefore, isFo
             {errorBefore && showAnyErrors && (
               <FormError field={field} />
             )}
-            {_.normalizeComponent(children, api)}
+            {_.normalizeComponent(children, { ...api, ...rest })}
             {!errorBefore && showAnyErrors && (
               <FormError field={field} />
             )}

--- a/src/formInput.js
+++ b/src/formInput.js
@@ -4,7 +4,7 @@ import classnames from 'classnames'
 import FormField from './formField'
 import FormError from './formError'
 
-export default function FormInput ({ field, showErrors = true, errorBefore, isForm, className, children: Child }) {
+export default function FormInput ({ field, showErrors = true, errorBefore, isForm, className, children }) {
   return (
     <FormField field={field}>
       {({ ...api }) => {
@@ -18,7 +18,7 @@ export default function FormInput ({ field, showErrors = true, errorBefore, isFo
             {errorBefore && showAnyErrors && (
               <FormError field={field} />
             )}
-            <Child {...api} />
+            {_.normalizeComponent(children, api)}
             {!errorBefore && showAnyErrors && (
               <FormError field={field} />
             )}

--- a/src/formInput.js
+++ b/src/formInput.js
@@ -4,7 +4,7 @@ import classnames from 'classnames'
 import FormField from './formField'
 import FormError from './formError'
 
-export default function FormInput ({ field, showErrors = true, errorBefore, isForm, className, children }) {
+export default function FormInput ({ field, showErrors = true, errorBefore, isForm, className, children: Child }) {
   return (
     <FormField field={field}>
       {({ ...api }) => {
@@ -18,7 +18,7 @@ export default function FormInput ({ field, showErrors = true, errorBefore, isFo
             {errorBefore && showAnyErrors && (
               <FormError field={field} />
             )}
-            {_.normalizeComponent(children, api)}
+            <Child {...api} />
             {!errorBefore && showAnyErrors && (
               <FormError field={field} />
             )}

--- a/src/formInputs/util.js
+++ b/src/formInputs/util.js
@@ -2,4 +2,3 @@ export const buildHandler = (override, fn) => e =>
   !override
     ? fn(e)
     : override(e, () => fn(e))
-

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+import React from 'react'
+
 export default {
   clone,
   get,
@@ -6,7 +8,8 @@ export default {
   makePathArray,
   pickBy,
   isObject,
-  isArray
+  isArray,
+  normalizeComponent
 }
 
 function clone (a) {
@@ -107,4 +110,14 @@ function isObject (a) {
 
 function isStringValidNumber (str) {
   return !isNaN(str)
+}
+
+function normalizeComponent (Comp, params = {}, fallback = Comp) {
+  return typeof Comp === 'function' ? (
+    Object.getPrototypeOf(Comp).isReactComponent ? (
+      <Comp
+        {...params}
+      />
+    ) : Comp(params)
+  ) : fallback
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 export default {
   clone,
   get,
@@ -6,7 +8,8 @@ export default {
   makePathArray,
   pickBy,
   isObject,
-  isArray
+  isArray,
+  normalizeComponent
 }
 
 function clone (a) {
@@ -107,4 +110,12 @@ function isObject (a) {
 
 function isStringValidNumber (str) {
   return !isNaN(str)
+}
+
+function normalizeComponent (Comp, props) {
+  return (
+    React.isValidElement(Comp) ? React.cloneElement(Comp, props) :
+    typeof Comp === 'function' ? <Comp {...props} /> : 
+      null
+  );
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,3 @@
-import React from 'react'
-
 export default {
   clone,
   get,
@@ -8,8 +6,7 @@ export default {
   makePathArray,
   pickBy,
   isObject,
-  isArray,
-  normalizeComponent
+  isArray
 }
 
 function clone (a) {
@@ -110,14 +107,4 @@ function isObject (a) {
 
 function isStringValidNumber (str) {
   return !isNaN(str)
-}
-
-function normalizeComponent (Comp, params = {}, fallback = Comp) {
-  return typeof Comp === 'function' ? (
-    Object.getPrototypeOf(Comp).isReactComponent ? (
-      <Comp
-        {...params}
-      />
-    ) : Comp(params)
-  ) : fallback
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'react'
 
 export default {
   clone,
@@ -114,8 +114,8 @@ function isStringValidNumber (str) {
 
 function normalizeComponent (Comp, props) {
   return (
-    React.isValidElement(Comp) ? React.cloneElement(Comp, props) :
-    typeof Comp === 'function' ? <Comp {...props} /> : 
-      null
-  );
+    React.isValidElement(Comp) ? React.cloneElement(Comp, props)
+    : typeof Comp === 'function' ? <Comp {...props} />
+      : null
+  )
 }


### PR DESCRIPTION
If `FormField`, `FormInput` and `Form` can accept a function that returns a JSX element as `children`, why couldn't it also accept a React Component as `children`? "A function that returns JSX element" **is** exactly a stateless functional component, isn't it?