### PR TITLE
Stop rendering empty div when no error

### DIFF
--- a/src/formError.js
+++ b/src/formError.js
@@ -9,13 +9,13 @@ export default function FormError ({ field, className, style }) {
       {({ getTouched, getError }) => {
         const touched = getTouched()
         const error = getError()
-        const styles = {
-          display: touched && error ? 'block' : 'none',
+        if (!(touched && typeof error === 'string' && error)) {
+          return null
         }
         const classes = classnames('FormError', className)
         return (
-          <div className={classes} style={Object.assign({}, styles, style)}>
-            {touched && typeof error === 'string' ? error : ''}
+          <div className={classes} style={style}>
+            {error}
           </div>
         )
       }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -787,14 +787,7 @@ babel-register@^6.24.1:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@^6.0.0:
-  version "6.20.0"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.20.0.tgz#87300bdcf4cd770f09bf0048c64204e17806d16f"
-  dependencies:
-    core-js "^2.4.0"
-    regenerator-runtime "^0.10.0"
-
-babel-runtime@^6.18.0, babel-runtime@^6.22.0:
+babel-runtime@^6.0.0, babel-runtime@^6.18.0, babel-runtime@^6.22.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
   dependencies:


### PR DESCRIPTION
In React you are better to return null or have a empty children rather than having the browser not show the error via a `display: none`, this also reduces the number of objects created by not creating the styles object and not creating another object with `Object.assign`