### PR TITLE
Fixed Form "componentWillUnmount" hook

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -93,7 +93,7 @@ class Form extends React.Component {
     )
   }
 
-  componentWillUmount () {
+  componentWillUnmount () {
     this.props.willUnmount(this.state, this.props, this)
   }
 


### PR DESCRIPTION
Fixed a typo that prevented the Form's "componentWillUnmount" hook from executing.