### PR TITLE
Fixing nonexistent reference to props.values

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -72,10 +72,11 @@ class Form extends React.Component {
   }
 
   componentWillReceiveProps (props) {
-    const { defaultValues, values } = props
+    const { defaultValues } = props
+    const { values } = this.state
     if (
       this.props.defaultValues === defaultValues &&
-      this.props.values === values
+      this.state.values === values
     ) {
       return
     }


### PR DESCRIPTION
I believe this should fix #118. The problem was that the code was referring to props.values, whereas the values are stored in state.