### PR TITLE
Normalize input fields' callbacks and props

### DIFF
--- a/src/components/form-fields/Checkbox.js
+++ b/src/components/form-fields/Checkbox.js
@@ -17,6 +17,7 @@ class CheckboxWrapper extends Component {
 
     const {
       fieldApi,
+      fieldDidUpdate,
       onChange,
       onBlur,
       ...rest
@@ -34,6 +35,12 @@ class CheckboxWrapper extends Component {
         checked={!!getValue()}
         onChange={(e) => {
           setValue(e.target.checked);
+          if (fieldDidUpdate) {
+            if (process.env.NODE_ENV === 'development') {
+              console.warn('fieldDidUpdate has been deprecated in favor of onChange. Please check the latest docs and update your app!')
+            }
+            fieldDidUpdate(e.target.checked);
+          }
           if (onChange) {
             onChange(e.target.checked, e);
           }

--- a/src/components/form-fields/Checkbox.js
+++ b/src/components/form-fields/Checkbox.js
@@ -17,7 +17,6 @@ class CheckboxWrapper extends Component {
 
     const {
       fieldApi,
-      fieldDidUpdate,
       onChange,
       onBlur,
       ...rest
@@ -35,12 +34,6 @@ class CheckboxWrapper extends Component {
         checked={!!getValue()}
         onChange={(e) => {
           setValue(e.target.checked);
-          if (fieldDidUpdate) {
-            if (process.env.NODE_ENV === 'development') {
-              console.warn('fieldDidUpdate has been deprecated in favor of onChange. Please check the latest docs and update your app!')
-            }
-            fieldDidUpdate(e.target.checked);
-          }
           if (onChange) {
             onChange(e.target.checked, e);
           }

--- a/src/components/form-fields/Checkbox.js
+++ b/src/components/form-fields/Checkbox.js
@@ -16,9 +16,9 @@ class CheckboxWrapper extends Component {
     // console.log('RENDER');
 
     const {
-      fieldDidUpdate,
       fieldApi,
       onChange,
+      onBlur,
       ...rest
     } = this.props;
 
@@ -30,19 +30,22 @@ class CheckboxWrapper extends Component {
 
     return (
       <input
+        {...rest}
         checked={!!getValue()}
-        onBlur={() => setTouched()}
         onChange={(e) => {
           setValue(e.target.checked);
           if (onChange) {
-            onChange(e);
+            onChange(e.target.checked, e);
           }
-          if ( fieldDidUpdate ) {
-            fieldDidUpdate( e.target.checked );
+        }}
+        onBlur={(e) => {
+          setTouched();
+          if ( onBlur ) {
+            onBlur(e);
           }
         }}
         type="checkbox"
-        {...rest} />
+      />
     );
   }
 }

--- a/src/components/form-fields/NestedForm.js
+++ b/src/components/form-fields/NestedForm.js
@@ -49,7 +49,8 @@ const NestedFormWrapper = (props) => {
       setSuccess( success ? successes : null );
       if ( asyncValidations > 0 ) {
         validatingField();
-      } else {
+      }
+      else {
         doneValidatingField();
       }
     },

--- a/src/components/form-fields/Radio.js
+++ b/src/components/form-fields/Radio.js
@@ -13,7 +13,6 @@ class Radio extends Component {
   render() {
 
     const {
-      onChange,
       onClick,
       group,
       value,
@@ -22,17 +21,21 @@ class Radio extends Component {
 
     return (
       <input
+        {...rest}
         checked={group.getValue() === value}
-        onBlur={() => group.setTouched()}
         onClick={(e) => {
           group.setValue(value);
-          group.fieldDidUpdate(value);
+          group.onChange(value, e);
           if (onClick) {
             onClick(e);
           }
         }}
+        onBlur={(e) => {
+          group.setTouched();
+          group.onBlur(e);
+        }}
         type="radio"
-        {...rest} />
+      />
     );
 
   }

--- a/src/components/form-fields/RadioGroup.js
+++ b/src/components/form-fields/RadioGroup.js
@@ -28,17 +28,10 @@ class RadioGroupWrapper extends Component {
       component,
       render,
       onChange,
-      fieldDidUpdate,
       onBlur
     } = this.props;
 
     fieldApi.onChange = ( val ) => {
-      if (fieldDidUpdate) {
-        if (process.env.NODE_ENV === 'development') {
-          console.warn('fieldDidUpdate has been deprecated in favor of onChange. Please check the latest docs and update your app!')
-        }
-        fieldDidUpdate(val);
-      }
       if ( onChange ) {
         onChange( val );
       }

--- a/src/components/form-fields/RadioGroup.js
+++ b/src/components/form-fields/RadioGroup.js
@@ -27,13 +27,19 @@ class RadioGroupWrapper extends Component {
       children,
       component,
       render,
-      fieldDidUpdate
+      onChange,
+      onBlur
     } = this.props;
 
-    // Add fieldDidUpdate to field api
-    fieldApi.fieldDidUpdate = ( val ) => {
-      if ( fieldDidUpdate ) {
-        fieldDidUpdate( val );
+    fieldApi.onChange = ( val ) => {
+      if ( onChange ) {
+        onChange( val );
+      }
+    };
+
+    fieldApi.onBlur = () => {
+      if (onBlur) {
+        onBlur();
       }
     };
 

--- a/src/components/form-fields/RadioGroup.js
+++ b/src/components/form-fields/RadioGroup.js
@@ -28,10 +28,17 @@ class RadioGroupWrapper extends Component {
       component,
       render,
       onChange,
+      fieldDidUpdate,
       onBlur
     } = this.props;
 
     fieldApi.onChange = ( val ) => {
+      if (fieldDidUpdate) {
+        if (process.env.NODE_ENV === 'development') {
+          console.warn('fieldDidUpdate has been deprecated in favor of onChange. Please check the latest docs and update your app!')
+        }
+        fieldDidUpdate(val);
+      }
       if ( onChange ) {
         onChange( val );
       }

--- a/src/components/form-fields/Select.js
+++ b/src/components/form-fields/Select.js
@@ -16,10 +16,10 @@ class SelectWrapper extends Component {
     // console.log('RENDER');
 
     const {
-      fieldDidUpdate,
       fieldApi,
       options,
       onChange,
+      onBlur,
       placeholder,
       ...rest
     } = this.props;
@@ -44,19 +44,22 @@ class SelectWrapper extends Component {
 
     return (
       <select
-        onBlur={() => setTouched()}
+        {...rest}
+        value={selectedIndex > -1 ? selectedIndex : nullIndex}
         onChange={(e) => {
           const val = resolvedOptions[e.target.value].value;
           setValue(val);
           if (onChange) {
-            onChange(e);
-          }
-          if ( fieldDidUpdate ) {
-            fieldDidUpdate( val );
+            onChange(val, e);
           }
         }}
-        value={selectedIndex > -1 ? selectedIndex : nullIndex}
-        {...rest}>
+        onBlur={(e) => {
+          setTouched();
+          if ( onBlur ) {
+            onBlur(e);
+          }
+        }}
+      >
         {resolvedOptions.map((option, i) => (
           <option
             key={option.value}

--- a/src/components/form-fields/Select.js
+++ b/src/components/form-fields/Select.js
@@ -19,6 +19,7 @@ class SelectWrapper extends Component {
       fieldApi,
       options,
       onChange,
+      fieldDidUpdate,
       onBlur,
       placeholder,
       ...rest
@@ -49,6 +50,12 @@ class SelectWrapper extends Component {
         onChange={(e) => {
           const val = resolvedOptions[e.target.value].value;
           setValue(val);
+          if (fieldDidUpdate) {
+            if (process.env.NODE_ENV === 'development') {
+              console.warn('fieldDidUpdate has been deprecated in favor of onChange. Please check the latest docs and update your app!')
+            }
+            fieldDidUpdate(val);
+          }
           if (onChange) {
             onChange(val, e);
           }

--- a/src/components/form-fields/Select.js
+++ b/src/components/form-fields/Select.js
@@ -19,7 +19,6 @@ class SelectWrapper extends Component {
       fieldApi,
       options,
       onChange,
-      fieldDidUpdate,
       onBlur,
       placeholder,
       ...rest
@@ -50,12 +49,6 @@ class SelectWrapper extends Component {
         onChange={(e) => {
           const val = resolvedOptions[e.target.value].value;
           setValue(val);
-          if (fieldDidUpdate) {
-            if (process.env.NODE_ENV === 'development') {
-              console.warn('fieldDidUpdate has been deprecated in favor of onChange. Please check the latest docs and update your app!')
-            }
-            fieldDidUpdate(val);
-          }
           if (onChange) {
             onChange(val, e);
           }

--- a/src/components/form-fields/Text.js
+++ b/src/components/form-fields/Text.js
@@ -19,6 +19,7 @@ class TextWrapper extends Component {
       fieldApi,
       onChange,
       onBlur,
+      fieldDidUpdate,
       ...rest
     } = this.props;
 
@@ -34,11 +35,16 @@ class TextWrapper extends Component {
         value={getValue() || ''}
         onChange={( e ) => {
           setValue(e.target.value);
+          if (fieldDidUpdate) {
+            if (process.env.NODE_ENV === 'development') {
+              console.warn('fieldDidUpdate has been deprecated in favor of onChange. Please check the latest docs and update your app!')
+            }
+            fieldDidUpdate(e.target.value);
+          }
           if ( onChange ) {
             onChange(e.target.value, e);
           }
-        }
-        }
+        }}
         onBlur={(e) => {
           setTouched();
           if ( onBlur ) {

--- a/src/components/form-fields/Text.js
+++ b/src/components/form-fields/Text.js
@@ -16,36 +16,36 @@ class TextWrapper extends Component {
     // console.log('RENDER');
 
     const {
-      fieldDidUpdate,
       fieldApi,
-      onInput,
+      onChange,
+      onBlur,
       ...rest
     } = this.props;
 
     const {
       getValue,
       setValue,
-      setTouched,
-      format
+      setTouched
     } = fieldApi;
 
     return (
       <input
+        {...rest}
         value={getValue() || ''}
-        onInput={( e ) => {
+        onChange={( e ) => {
           setValue(e.target.value);
-          if ( fieldDidUpdate ) {
-            fieldDidUpdate(e.target.value);
-          }
-          if ( onInput ) {
-            onInput( e );
+          if ( onChange ) {
+            onChange(e.target.value, e);
           }
         }
         }
-        onBlur={() => {
+        onBlur={(e) => {
           setTouched();
+          if ( onBlur ) {
+            onBlur(e);
+          }
         }}
-        {...rest} />
+      />
     );
   }
 }

--- a/src/components/form-fields/Text.js
+++ b/src/components/form-fields/Text.js
@@ -10,38 +10,26 @@ import PropTypes from 'prop-types';
 import FormField from '../FormField';
 
 class TextWrapper extends Component {
-
   render() {
-
     // console.log('RENDER');
 
-    const {
-      fieldApi,
-      onChange,
-      onBlur,
-      ...rest
-    } = this.props;
+    const { fieldApi, onChange, onBlur, ...rest } = this.props;
 
-    const {
-      getValue,
-      setValue,
-      setTouched
-    } = fieldApi;
+    const { getValue, setValue, setTouched } = fieldApi;
 
     return (
       <input
         {...rest}
         value={getValue() || ''}
-        onChange={( e ) => {
+        onChange={(e) => {
           setValue(e.target.value);
-          if ( onChange ) {
+          if (onChange) {
             onChange(e.target.value, e);
           }
-        }
-        }
+        }}
         onBlur={(e) => {
           setTouched();
-          if ( onBlur ) {
+          if (onBlur) {
             onBlur(e);
           }
         }}
@@ -51,14 +39,10 @@ class TextWrapper extends Component {
 }
 
 class Text extends Component {
-
   render() {
-    const {
-      field,
-      ...rest
-    } = this.props;
+    const { field, ...rest } = this.props;
 
-    //console.log("REST", rest);
+    // console.log("REST", rest);
     // console.log("RENDER1");
 
     return (
@@ -67,14 +51,10 @@ class Text extends Component {
       </FormField>
     );
   }
-
 }
 
 Text.propTypes = {
-  field: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.array,
-  ]).isRequired,
+  field: PropTypes.oneOfType([PropTypes.string, PropTypes.array]).isRequired,
 };
 
 export default Text;

--- a/src/components/form-fields/Text.js
+++ b/src/components/form-fields/Text.js
@@ -19,7 +19,6 @@ class TextWrapper extends Component {
       fieldApi,
       onChange,
       onBlur,
-      fieldDidUpdate,
       ...rest
     } = this.props;
 
@@ -35,16 +34,11 @@ class TextWrapper extends Component {
         value={getValue() || ''}
         onChange={( e ) => {
           setValue(e.target.value);
-          if (fieldDidUpdate) {
-            if (process.env.NODE_ENV === 'development') {
-              console.warn('fieldDidUpdate has been deprecated in favor of onChange. Please check the latest docs and update your app!')
-            }
-            fieldDidUpdate(e.target.value);
-          }
           if ( onChange ) {
             onChange(e.target.value, e);
           }
-        }}
+        }
+        }
         onBlur={(e) => {
           setTouched();
           if ( onBlur ) {

--- a/src/components/form-fields/TextArea.js
+++ b/src/components/form-fields/TextArea.js
@@ -19,7 +19,6 @@ class TextAreaWrapper extends Component {
       onChange,
       onBlur,
       fieldApi,
-      fieldDidUpdate,
       ...rest
     } = this.props;
 
@@ -35,12 +34,6 @@ class TextAreaWrapper extends Component {
         value={getValue() || ''}
         onChange={( e ) => {
           setValue(e.target.value);
-          if (fieldDidUpdate) {
-            if (process.env.NODE_ENV === 'development') {
-              console.warn('fieldDidUpdate has been deprecated in favor of onChange. Please check the latest docs and update your app!')
-            }
-            fieldDidUpdate(e.target.value);
-          }
           if ( onChange ) {
             onChange(e.target.value, e);
           }

--- a/src/components/form-fields/TextArea.js
+++ b/src/components/form-fields/TextArea.js
@@ -17,9 +17,8 @@ class TextAreaWrapper extends Component {
 
     const {
       onChange,
+      onBlur,
       fieldApi,
-      fieldDidUpdate,
-      onInput,
       ...rest
     } = this.props;
 
@@ -31,18 +30,21 @@ class TextAreaWrapper extends Component {
 
     return (
       <textarea
+        {...rest}
         value={getValue() || ''}
-        onInput={( e ) => {
+        onChange={( e ) => {
           setValue(e.target.value);
-          if ( fieldDidUpdate ) {
-            fieldDidUpdate(e.target.value);
-          }
-          if ( onInput ) {
-            onInput( e );
+          if ( onChange ) {
+            onChange(e.target.value, e);
           }
         }}
-        onBlur={() => setTouched()}
-        {...rest} />
+        onBlur={(e) => {
+          setTouched();
+          if ( onBlur ) {
+            onBlur(e);
+          }
+        }}
+      />
     );
 
   }

--- a/src/components/form-fields/TextArea.js
+++ b/src/components/form-fields/TextArea.js
@@ -19,6 +19,7 @@ class TextAreaWrapper extends Component {
       onChange,
       onBlur,
       fieldApi,
+      fieldDidUpdate,
       ...rest
     } = this.props;
 
@@ -34,6 +35,12 @@ class TextAreaWrapper extends Component {
         value={getValue() || ''}
         onChange={( e ) => {
           setValue(e.target.value);
+          if (fieldDidUpdate) {
+            if (process.env.NODE_ENV === 'development') {
+              console.warn('fieldDidUpdate has been deprecated in favor of onChange. Please check the latest docs and update your app!')
+            }
+            fieldDidUpdate(e.target.value);
+          }
           if ( onChange ) {
             onChange(e.target.value, e);
           }


### PR DESCRIPTION
- All inputs now internally use `onChange` instead of `onInput` as per recommended via React best practices.
- All inputs now consistently use and proxy `onBlur`.
- All inputs now consistently use a hybrid `onChange(newValue, event)` callback, instead of a separate `fieldDidUpdate` and `onChange` prop.
- All inputs now apply `...rest` props so as to not accidentally clobber internal props.

Fixes #132 