### PR TITLE
Move babel config to .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,12 @@
+{
+  "presets": [
+    "env",
+    "stage-0",
+    "react"
+  ],
+  "plugins": [
+    "react-hot-loader/babel",
+    "transform-runtime",
+    "transform-class-properties"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "babel-core": "^6.26.0",
     "babel-eslint": "^7.2.3",
     "babel-loader": "^7.1.1",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.0",
     "babel-preset-react": "^6.24.1",
@@ -91,16 +92,5 @@
     "webpack": "^3.5.5",
     "webpack-dev-server": "^2.7.1",
     "webpack-node-externals": "^1.6.0"
-  },
-  "babel": {
-    "presets": [
-      "env",
-      "stage-0",
-      "react"
-    ],
-    "plugins": [
-      "react-hot-loader/babel",
-      "transform-runtime"
-    ]
   }
 }

--- a/src/components/ReduxForm.js
+++ b/src/components/ReduxForm.js
@@ -57,6 +57,12 @@ class Form extends Component {
   constructor(props) {
     super(props);
     this.asyncValidators = [];
+
+    // Unfortunately, babel has some stupid bug with auto-binding async arrow functions
+    // So we still need to manually bind them here
+    // https://github.com/gaearon/react-hot-loader/issues/391
+    this.finishSubmission = this.finishSubmission.bind(this);
+    this.callAsynchronousValidators = this.callAsynchronousValidators.bind(this);
   }
 
   getChildContext() {
@@ -293,7 +299,7 @@ class Form extends Component {
     this.finishSubmission();
   }
 
-  finishSubmission = async (e) => {
+  async finishSubmission(e) {
     // Call asynchronous validators
     await this.callAsynchronousValidators();
     // Only submit if we have no errors
@@ -309,7 +315,7 @@ class Form extends Component {
     }
   }
 
-  callAsynchronousValidators = async () => {
+  async callAsynchronousValidators() {
     // Build up list of async functions that need to be called
     let validators = this.props.asyncValidators ? Object.keys(this.props.asyncValidators).map( ( field ) => {
       return this.props.dispatch(actions.asyncValidate(field, this.props.asyncValidators ));

--- a/src/components/ReduxForm.js
+++ b/src/components/ReduxForm.js
@@ -55,7 +55,30 @@ const newState = ( state ) => {
 class Form extends Component {
 
   constructor(props) {
+
     super(props);
+
+    this.getValue = this.getValue.bind(this);
+    this.setValue = this.setValue.bind(this);
+    this.addValue = this.addValue.bind(this);
+    this.removeValue = this.removeValue.bind(this);
+    this.getTouched = this.getTouched.bind(this);
+    this.setTouched = this.setTouched.bind(this);
+    this.setError = this.setError.bind(this);
+    this.format = this.format.bind(this);
+    this.setWarning = this.setWarning.bind(this);
+    this.setSuccess = this.setSuccess.bind(this);
+    this.submitForm = this.submitForm.bind(this);
+    this.reset = this.reset.bind(this);
+    this.resetAll = this.resetAll.bind(this);
+    this.getError = this.getError.bind(this);
+    this.getWarning = this.getWarning.bind(this);
+    this.getSuccess = this.getSuccess.bind(this);
+    this.doneValidatingField = this.doneValidatingField.bind(this);
+    this.validatingField = this.validatingField.bind(this);
+    this.registerAsyncValidation = this.registerAsyncValidation.bind(this);
+    this.callAsynchronousValidators = this.callAsynchronousValidators.bind(this);
+
     this.asyncValidators = [];
 
     // Unfortunately, babel has some stupid bug with auto-binding async arrow functions
@@ -168,7 +191,7 @@ class Form extends Component {
     });
   }
 
-  setValue = ( field, value ) => {
+  setValue( field, value ) {
     this.props.dispatch(actions.setValue(field, value));
     this.props.dispatch(actions.removeAsyncError(field));
     this.props.dispatch(actions.removeAsyncWarning(field));
@@ -177,7 +200,7 @@ class Form extends Component {
     this.props.dispatch(actions.validate());
   }
 
-  setTouched = ( field, touch = true, validate = true ) => {
+  setTouched( field, touch = true, validate = true ) {
     this.props.dispatch(actions.setTouched(field, touch));
     // We have a flag to perform async validate when touched
     if ( validate ) {
@@ -185,42 +208,42 @@ class Form extends Component {
     }
   }
 
-  setError = ( field, error ) => {
+  setError( field, error ) {
     this.props.dispatch(actions.setError(field, error));
   }
 
-  setWarning = ( field, warning ) => {
+  setWarning( field, warning ) {
     this.props.dispatch(actions.setWarning(field, warning));
   }
 
-  setSuccess = ( field, success ) => {
+  setSuccess( field, success ) {
     this.props.dispatch(actions.setSuccess(field, success));
   }
 
-  getTouched = ( field ) => {
+  getTouched( field ) {
     if ( Array.isArray(field) ) {
       return this.props.formState.touched[field[0]] ? this.props.formState.touched[field[0]][field[1]] : undefined;
     }
     return this.props.formState.touched[field];
   }
 
-  getValue = ( field ) => {
+  getValue( field ) {
     return Utils.get( this.props.formState.values, field );
   }
 
-  getError = ( field ) => {
+  getError( field ) {
     return Utils.get( this.errors, field );
   }
 
-  getWarning = ( field ) => {
+  getWarning( field ) {
     return Utils.get( this.warnings, field );
   }
 
-  getSuccess = ( field ) => {
+  getSuccess( field ) {
     return Utils.get( this.successes, field );
   }
 
-  addValue = ( field, value ) => {
+  addValue( field, value ) {
     this.props.dispatch(actions.setValue(field, [
       ...( Utils.get( this.props.formState.values, field ) || []),
       value,
@@ -232,7 +255,7 @@ class Form extends Component {
     this.props.dispatch(actions.validate());
   }
 
-  removeValue = ( field, index ) => {
+  removeValue( field, index ) {
     const fieldValue = Utils.get( this.props.formState.values, field ) || [];
     this.props.dispatch(actions.setValue( field, [
       ...fieldValue.slice(0, index),
@@ -250,35 +273,35 @@ class Form extends Component {
     this.props.dispatch(actions.validate());
   }
 
-  registerAsyncValidation = ( func ) => {
+  registerAsyncValidation( func ) {
     this.asyncValidators.push( func );
   }
 
-  format = ( field, format ) => {
+  format( field, format ) {
     this.props.dispatch(actions.format(field, format));
     this.props.dispatch(actions.preValidate());
     this.props.dispatch(actions.validate());
   }
 
-  reset = ( field ) => {
+  reset( field ) {
     this.props.dispatch(actions.reset(field));
   }
 
-  resetAll = () => {
+  resetAll() {
     this.props.dispatch(actions.resetAll());
   }
 
   // This is an internal method used by nested forms to tell the parent that its validating
-  validatingField = ( field ) => {
+  validatingField( field ) {
     this.props.dispatch(actions.validatingField(field));
   }
 
   // This is an internal method used by nested forms to tell the parent that its done validating
-  doneValidatingField = ( field ) => {
+  doneValidatingField( field ) {
     this.props.dispatch(actions.doneValidatingField(field));
   }
 
-  submitForm = ( e ) => {
+  submitForm( e ) {
     // PreValidate
     this.props.dispatch(actions.preValidate());
     // Validate

--- a/src/components/ReduxForm.js
+++ b/src/components/ReduxForm.js
@@ -55,30 +55,7 @@ const newState = ( state ) => {
 class Form extends Component {
 
   constructor(props) {
-
     super(props);
-
-    this.getValue = this.getValue.bind(this);
-    this.setValue = this.setValue.bind(this);
-    this.addValue = this.addValue.bind(this);
-    this.removeValue = this.removeValue.bind(this);
-    this.getTouched = this.getTouched.bind(this);
-    this.setTouched = this.setTouched.bind(this);
-    this.setError = this.setError.bind(this);
-    this.format = this.format.bind(this);
-    this.setWarning = this.setWarning.bind(this);
-    this.setSuccess = this.setSuccess.bind(this);
-    this.submitForm = this.submitForm.bind(this);
-    this.reset = this.reset.bind(this);
-    this.resetAll = this.resetAll.bind(this);
-    this.getError = this.getError.bind(this);
-    this.getWarning = this.getWarning.bind(this);
-    this.getSuccess = this.getSuccess.bind(this);
-    this.doneValidatingField = this.doneValidatingField.bind(this);
-    this.validatingField = this.validatingField.bind(this);
-    this.registerAsyncValidation = this.registerAsyncValidation.bind(this);
-    this.callAsynchronousValidators = this.callAsynchronousValidators.bind(this);
-
     this.asyncValidators = [];
 
     // Unfortunately, babel has some stupid bug with auto-binding async arrow functions
@@ -191,7 +168,7 @@ class Form extends Component {
     });
   }
 
-  setValue( field, value ) {
+  setValue = ( field, value ) => {
     this.props.dispatch(actions.setValue(field, value));
     this.props.dispatch(actions.removeAsyncError(field));
     this.props.dispatch(actions.removeAsyncWarning(field));
@@ -200,7 +177,7 @@ class Form extends Component {
     this.props.dispatch(actions.validate());
   }
 
-  setTouched( field, touch = true, validate = true ) {
+  setTouched = ( field, touch = true, validate = true ) => {
     this.props.dispatch(actions.setTouched(field, touch));
     // We have a flag to perform async validate when touched
     if ( validate ) {
@@ -208,42 +185,42 @@ class Form extends Component {
     }
   }
 
-  setError( field, error ) {
+  setError = ( field, error ) => {
     this.props.dispatch(actions.setError(field, error));
   }
 
-  setWarning( field, warning ) {
+  setWarning = ( field, warning ) => {
     this.props.dispatch(actions.setWarning(field, warning));
   }
 
-  setSuccess( field, success ) {
+  setSuccess = ( field, success ) => {
     this.props.dispatch(actions.setSuccess(field, success));
   }
 
-  getTouched( field ) {
+  getTouched = ( field ) => {
     if ( Array.isArray(field) ) {
       return this.props.formState.touched[field[0]] ? this.props.formState.touched[field[0]][field[1]] : undefined;
     }
     return this.props.formState.touched[field];
   }
 
-  getValue( field ) {
+  getValue = ( field ) => {
     return Utils.get( this.props.formState.values, field );
   }
 
-  getError( field ) {
+  getError = ( field ) => {
     return Utils.get( this.errors, field );
   }
 
-  getWarning( field ) {
+  getWarning = ( field ) => {
     return Utils.get( this.warnings, field );
   }
 
-  getSuccess( field ) {
+  getSuccess = ( field ) => {
     return Utils.get( this.successes, field );
   }
 
-  addValue( field, value ) {
+  addValue = ( field, value ) => {
     this.props.dispatch(actions.setValue(field, [
       ...( Utils.get( this.props.formState.values, field ) || []),
       value,
@@ -255,7 +232,7 @@ class Form extends Component {
     this.props.dispatch(actions.validate());
   }
 
-  removeValue( field, index ) {
+  removeValue = ( field, index ) => {
     const fieldValue = Utils.get( this.props.formState.values, field ) || [];
     this.props.dispatch(actions.setValue( field, [
       ...fieldValue.slice(0, index),
@@ -273,35 +250,35 @@ class Form extends Component {
     this.props.dispatch(actions.validate());
   }
 
-  registerAsyncValidation( func ) {
+  registerAsyncValidation = ( func ) => {
     this.asyncValidators.push( func );
   }
 
-  format( field, format ) {
+  format = ( field, format ) => {
     this.props.dispatch(actions.format(field, format));
     this.props.dispatch(actions.preValidate());
     this.props.dispatch(actions.validate());
   }
 
-  reset( field ) {
+  reset = ( field ) => {
     this.props.dispatch(actions.reset(field));
   }
 
-  resetAll() {
+  resetAll = () => {
     this.props.dispatch(actions.resetAll());
   }
 
   // This is an internal method used by nested forms to tell the parent that its validating
-  validatingField( field ) {
+  validatingField = ( field ) => {
     this.props.dispatch(actions.validatingField(field));
   }
 
   // This is an internal method used by nested forms to tell the parent that its done validating
-  doneValidatingField( field ) {
+  doneValidatingField = ( field ) => {
     this.props.dispatch(actions.doneValidatingField(field));
   }
 
-  submitForm( e ) {
+  submitForm = ( e ) => {
     // PreValidate
     this.props.dispatch(actions.preValidate());
     // Validate


### PR DESCRIPTION
This uses the latest class binding syntax for instance-bound methods.  No more rebinding :)