### PR TITLE
Add getApi prop and docs

### DIFF
--- a/dev/Intro.js
+++ b/dev/Intro.js
@@ -508,6 +508,17 @@ const FormProps = () => {
                default, regardless of this prop.
             </td>
           </tr>
+          <tr>
+            <th scope="row"><code>getApi</code></th>
+            <td><pre>function</pre></td>
+            <td>no</td>
+            <td>
+              To retrieve the form api as a callback, you can pass a function to the `getApi` prop.
+              Your function will be called with the formApi as the only parameter. You can save this as a reference
+              to easily manipulate your form from outside of the form scope.
+              <pre><PrismCode className="language-jsx">{`getApi( formApi )`}</PrismCode></pre>
+            </td>
+          </tr>
         </tbody>
       </table>
     </div>

--- a/src/components/ReduxForm.js
+++ b/src/components/ReduxForm.js
@@ -65,6 +65,12 @@ class Form extends Component {
     };
   }
 
+  componentWillMount() {
+    if (this.props.getApi) {
+      this.props.getApi(this.api);
+    }
+  }
+
   componentDidMount() {
     if ( !this.props.dontValidateOnMount ) {
       // PreValidat


### PR DESCRIPTION
allows retrieving an instance of the api from a parent component, much like using a `ref`. :)