### PR TITLE
Add getFieldName to fieldApi for getting field name of custom input

### DIFF
--- a/src/components/FormField.js
+++ b/src/components/FormField.js
@@ -84,6 +84,7 @@ function FormField(FormComponent) {
         setSuccess: ( success ) => {
           formApi.setSuccess( field, success );
         },
+        getFieldName: ( ) => field,
         getValue: ( ) => formApi.getValue( field ),
         getTouched: ( ) => formApi.getTouched( field ),
         getError: ( ) => formApi.getError( field ),


### PR DESCRIPTION
I'm writing a custom input which based on `RadioGroup` component, I couldn't get `field` property from props because `field` was destructed from Component props.

https://github.com/react-tools/react-form/blob/5c7c76cda719256f1401d2aa06c75a1174a9b025/src/components/FormField.js#L65

Here's my implementation:
```
const RadioGroup = FormField(({ options, fieldName, disabled }) => {
  if (!options || options.length === 0) {
    return false
  }

  return (
    <_RadioGroup field={fieldName}>
      {group =>
        options.map((option, i) => (
          <label key={i}>
            <Radio
              group={group}
              className='radio'
              value={option.value}
              disabled={disabled}
            />
            <span>{option.label}</span>
          </label>
        ))}
    </_RadioGroup>
  )
})
```

After adding `getFieldName` to `FormField`, we can retrieve the field name by:
```
const { fieldApi: { getFieldName } } = props
const fieldName = getFieldName()
```

Other solution is changing `<FormComponent fieldApi={fieldApi} {...rest} />` to `<FormComponent fieldApi={fieldApi} {...this.props} />` but I'm not sure which is better.

Please let me know your opinion. Thank you in advance.