### PR TITLE
Avoid to merge old and new errors/warnings/successes

### DIFF
--- a/src/redux/ReducerBuilder.js
+++ b/src/redux/ReducerBuilder.js
@@ -325,10 +325,10 @@ const removeAsyncSuccess = ( state, action ) => {
 
 const validate = ( state, action, validateError, validateWarning, validateSuccess ) => {
 
-  const errors = validateError ? validateError( state.values ) : {};
-  const warnings = validateWarning ? validateWarning( state.values ) : {};
-  const successes = validateSuccess ? validateSuccess( state.values, errors ) : {};
-  
+  const errors = validateError ? validateError( state.values ) : state.errors;
+  const warnings = validateWarning ? validateWarning( state.values ) : state.warnings;
+  const successes = validateSuccess ? validateSuccess( state.values, errors ) : state.successes;
+
   return {
     ...state,
     errors,

--- a/src/redux/ReducerBuilder.js
+++ b/src/redux/ReducerBuilder.js
@@ -325,12 +325,10 @@ const removeAsyncSuccess = ( state, action ) => {
 
 const validate = ( state, action, validateError, validateWarning, validateSuccess ) => {
 
-  let errors = validateError ? validateError( state.values ) : {};
-  let warnings = validateWarning ? validateWarning( state.values ) : {};
-  let successes = validateSuccess ? validateSuccess( state.values, errors ) : {};
-  errors = { ...state.errors, ...errors };
-  warnings = { ...state.warnings, ...warnings };
-  successes = { ...state.successes, ...successes };
+  const errors = validateError ? validateError( state.values ) : {};
+  const warnings = validateWarning ? validateWarning( state.values ) : {};
+  const successes = validateSuccess ? validateSuccess( state.values, errors ) : {};
+  
   return {
     ...state,
     errors,


### PR DESCRIPTION
This changes to prevent the merging old and new errors/warnings/successes.

For example,
My validation framework (modified `JOI`) for `validateError` callback returns object with only fields with errors:
`{
  firstName: 'First Name is required'
}`
not like 
`{
  firstName: 'First Name is required',
  lastName: null
}`

If form is valid then `validateError` callback returns empty object `{}`.

Original implementation does not remove old error messages.

Thanks