### PR TITLE
Make it faster for big forms

### DIFF
--- a/src/redux/utils.js
+++ b/src/redux/utils.js
@@ -77,9 +77,7 @@ function get(obj, path, def) {
   }
   const pathObj = makePathArray(path);
   let val;
-  try {
-    val = pathObj.reduce((current, pathPart) => current[pathPart], obj);
-  } catch (e) {}
+  val = pathObj.reduce((current, pathPart) => (typeof current !== 'undefined' ? current[pathPart] : undefined), obj);
   return typeof val !== 'undefined' ? val : def;
 }
 


### PR DESCRIPTION
This try-catch impacts hugely on performance for big forms. After profiling and removal, my input updates become faster about 3 times. But performance is still not very good due to full form re-rendering