### PR TITLE
Prevent error that had been previously swallowed by try/catch

### DIFF
--- a/src/redux/utils.js
+++ b/src/redux/utils.js
@@ -76,8 +76,12 @@ function get(obj, path, def) {
     return obj;
   }
   const pathObj = makePathArray(path);
-  let val;
-  val = pathObj.reduce((current, pathPart) => (typeof current !== 'undefined' ? current[pathPart] : undefined), obj);
+  const val = pathObj.reduce((current, pathPart) => {
+    if (typeof current !== 'undefined' && current !== null) {
+      return current[pathPart];
+    }
+    return undefined;
+  }, obj);
   return typeof val !== 'undefined' ? val : def;
 }
 


### PR DESCRIPTION
https://github.com/react-tools/react-form/pull/206 removed a try/catch in the `get` utility function. This try/catch had been previously swallowing errors when it tried to access a value on `null`.