### PR TITLE
catch errors during onSubmit

### DIFF
--- a/dev/Intro.js
+++ b/dev/Intro.js
@@ -513,9 +513,11 @@ const FormProps = () => {
             <td><pre>func</pre></td>
             <td>no</td>
             <td>
-              Function that gets called when submission fails due to errors.
-              This function will pass two parameters: the form errors, and the formApi. <br />
-              <pre><PrismCode className="language-jsx">onSubmitFailure( errors, formApi )</PrismCode></pre>
+              Function that gets called when submission fails due to errors, or when
+              <code>onSubmit</code> threw an error.
+              This function will pass two parameters: the form validation errors, the formApi, and
+              an error thrown during the call to <code>onSubmit</code>. <br />
+              <pre><PrismCode className="language-jsx">onSubmitFailure( errors, formApi, onSubmitError )</PrismCode></pre>
             </td>
           </tr>
           <tr>

--- a/src/components/ReduxForm.js
+++ b/src/components/ReduxForm.js
@@ -402,7 +402,12 @@ class Form extends Component {
       // Update submitted
       this.props.dispatch(actions.submitted());
       if ( this.props.onSubmit ) {
-        this.props.onSubmit( values, e, this.api );
+        try {
+          await this.props.onSubmit( values, e, this.api );
+        }
+        catch (error) {
+          this.props.onSubmitFailure( {}, this.api, error );
+        }
       }
     }
     // Let the user know we are done submitting

--- a/test/components/ReduxForm.spec.js
+++ b/test/components/ReduxForm.spec.js
@@ -512,4 +512,52 @@ describe('ReduxForm', () => {
 
   });
 
+  it('should call onSubmitFailure function when submit throws', (done) => {
+    const spy = sandbox.spy();
+    const error = new Error('Submission Error');
+    const wrapper = mount(
+      <Form onSubmitFailure={spy} onSubmit={() => { throw error; }}>
+        { ({ submitForm }) => (
+          <form onSubmit={submitForm}>
+            <Text field="greeting" />
+            <button type="submit">Submit</button>
+          </form>
+        ) }
+      </Form>
+    );
+    const button = wrapper.find('button');
+    button.simulate('submit');
+    setImmediate( () => {
+      expect(spy.called).to.equal( true );
+      const { args: [[validationErrors,, submitError]] } = spy;
+      expect(validationErrors).to.deep.equal({});
+      expect(submitError).to.equal(error);
+      done();
+    });
+  });
+
+  it('should call onSubmitFailure function when submit throws (async)', (done) => {
+    const spy = sandbox.spy();
+    const error = new Error('Submission Error');
+    const wrapper = mount(
+      <Form onSubmitFailure={spy} onSubmit={async () => { throw error; }}>
+        { ({ submitForm }) => (
+          <form onSubmit={submitForm}>
+            <Text field="greeting" />
+            <button type="submit">Submit</button>
+          </form>
+        ) }
+      </Form>
+    );
+    const button = wrapper.find('button');
+    button.simulate('submit');
+    setImmediate( () => {
+      expect(spy.called).to.equal( true );
+      const { args: [[validationErrors,, submitError]] } = spy;
+      expect(validationErrors).to.deep.equal({});
+      expect(submitError).to.equal(error);
+      done();
+    });
+  });
+
 });


### PR DESCRIPTION
This allows to handle `onSubmit` errors in `onSubmitFailure`, e.g.,
```jsx
onSubmit={async (result) => {
    await fetchData('/api', result);
}}
onSubmitFailure={(validationErrors, formApi, fetchError) => {
    this.setState({ fetchError, validationErrors });
}}
```