### PR TITLE
Allow passing false to select placeholder option

### DIFF
--- a/src/components/form-fields/Select.js
+++ b/src/components/form-fields/Select.js
@@ -15,7 +15,7 @@ class SelectWrapper extends Component {
       ...rest
     } = this.props
 
-    const resolvedOptions = options.find(d => d.value === '')
+    const resolvedOptions = options.find(d => d.value === '') || placeholder === false
       ? options
       : [
         {


### PR DESCRIPTION
Hi,

I'd like to have the possibility not to have any placeholder on selects for fields that always have a default and no possible empty values

I think passing placeholder={false} to selects makes sense

if this is ok for you can we publish it as a 2.x release?