### PR TITLE
Form removeValue should reset errors

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -313,6 +313,13 @@ class Form extends Component {
         value: [...fieldTouched.slice(0, index), ...fieldTouched.slice(index + 1)]
       })
     )
+    const fieldError = Utils.get(this.props.formState.errors, field) || []
+    this.props.dispatch(
+      actions.setError({
+        field,
+        value: [...fieldError.slice(0, index), ...fieldError.slice(index + 1)]
+      })
+    )
   }
 
   swapValues = (field, index, destIndex) => {

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -299,27 +299,19 @@ class Form extends Component {
   }
 
   removeValue = (field, index) => {
-    const fieldValue = Utils.get(this.props.formState.values, field) || []
-    this.props.dispatch(
-      actions.setValue({
-        field,
-        value: [...fieldValue.slice(0, index), ...fieldValue.slice(index + 1)]
-      })
-    )
-    const fieldTouched = Utils.get(this.props.formState.touched, field) || []
-    this.props.dispatch(
-      actions.setTouched({
-        field,
-        value: [...fieldTouched.slice(0, index), ...fieldTouched.slice(index + 1)]
-      })
-    )
-    const fieldError = Utils.get(this.props.formState.errors, field) || []
-    this.props.dispatch(
-      actions.setError({
-        field,
-        value: [...fieldError.slice(0, index), ...fieldError.slice(index + 1)]
-      })
-    )
+    [
+      { attribute: 'values', action: 'setValue' },
+      { attribute: 'touched', action: 'setTouched' },
+      { attribute: 'errors', action: 'setError' },
+    ].forEach(({ attribute, action }) => {
+      const fieldAttribute = Utils.get(this.props.formState[attribute], field) || []
+      this.props.dispatch(
+        actions[action]({
+          field,
+          value: [...fieldAttribute.slice(0, index), ...fieldAttribute.slice(index + 1)],
+        })
+      )
+    })
   }
 
   swapValues = (field, index, destIndex) => {

--- a/tests/components/Form.spec.js
+++ b/tests/components/Form.spec.js
@@ -566,4 +566,23 @@ describe('Form', () => {
       done()
     })
   })
+
+  describe('remove value', () => {
+    let api
+    const setApi = param => {
+      api = param
+    }
+
+    beforeEach(() => {
+      mount(<Form getApi={setApi}>{api => <form onSubmit={api.submitForm} />}</Form>)
+    })
+
+    it('remove errors when removing value', () => {
+      api.setError(['arrayFields', 0], 'foo')
+      api.setError(['arrayFields', 1], 'error')
+      api.setError(['arrayFields', 2], 'bar')
+      api.removeValue('arrayFields', 1)
+      expect(api.getError('arrayFields')).to.eql(['foo', 'bar'])
+    })
+  })
 })


### PR DESCRIPTION
Hello, we use react-form in one of our project.
With an array-field when we remove value, we could see that the errors where not updated.
Here is a fix.

I also took some liberty to add a small refactor commit.
Just tell me what do you think of this one, as it is not necessary (the real fix is in the first commit).