### PR TITLE
Radio input value

### DIFF
--- a/src/components/form-fields/Radio.js
+++ b/src/components/form-fields/Radio.js
@@ -30,6 +30,7 @@ class Radio extends Component {
     return (
       <input
         {...rest}
+        value={value}
         checked={groupValue === value}
         onChange={e => {
           if (!e.target.checked) {

--- a/tests/components/form-fields/Radio.spec.js
+++ b/tests/components/form-fields/Radio.spec.js
@@ -13,6 +13,12 @@ describe('RadioButton', () => {
     sandbox.restore()
   })
 
+  it('should pass value to the vanilla input', () => {
+    const wrapper = mount(<Radio id="radio-example-yes" value="yes" radioGroup={{}} />)
+    const input = wrapper.find('input').at(0)
+    expect(input.prop('value')).to.equal('yes')
+  })
+
   it('should update value when user clicks radio', () => {
     let savedApi
     const wrapper = mount(


### PR DESCRIPTION
Hello, while testing Radio inputs using capybara, we could see that the inputs all have `value="on"`.

<img width="318" alt="screen shot 2018-03-18 at 20 08 30" src="https://user-images.githubusercontent.com/5465485/37569846-521c2e70-2ae8-11e8-813a-192d353308f6.png">

We would like to have the value passed to the input vanilla.