### PR TITLE
Fixing defaultProps Warning in Select Component

### DIFF
--- a/src/components/form-fields/Select.js
+++ b/src/components/form-fields/Select.js
@@ -30,6 +30,10 @@ class SelectWrapper extends Component {
     const nullIndex = resolvedOptions.findIndex(d => d.value === '')
     const selectedIndex = resolvedOptions.findIndex(d => d.value === value)
     const initialIndex = resolvedOptions.findIndex(d => d.value === initalValue)
+    if (selectedIndex <= -1 && initialIndex > -1) {
+      const val = resolvedOptions[initialIndex].value
+      setValue(val)
+    }
 
     return (
       <select

--- a/src/components/form-fields/Select.js
+++ b/src/components/form-fields/Select.js
@@ -12,6 +12,7 @@ class SelectWrapper extends Component {
       onChange,
       onBlur,
       placeholder,
+      initalValue,
       ...rest
     } = this.props
 
@@ -28,11 +29,12 @@ class SelectWrapper extends Component {
 
     const nullIndex = resolvedOptions.findIndex(d => d.value === '')
     const selectedIndex = resolvedOptions.findIndex(d => d.value === value)
+    const initialIndex = resolvedOptions.findIndex(d => d.value === initalValue)
 
     return (
       <select
         {...rest}
-        value={selectedIndex > -1 ? selectedIndex : nullIndex}
+        value={selectedIndex > -1 ? selectedIndex : initialIndex > -1 ? initialIndex : nullIndex}
         onChange={e => {
           const val = resolvedOptions[e.target.value].value
           setValue(val)


### PR DESCRIPTION
This fixes #306 
The approach is to provide an `initialValue` prop for setting the
initial value rather than `defaultValue` since the component is not
uncontrolled. I then check the `selectedIndex` and `initialValueIndex`
(if provided) when setting the `value` prop of the HTML <select> element.