### PR TITLE
Field: validate on mount for dynamic forms

### DIFF
--- a/demo/src/DynamicForms.js
+++ b/demo/src/DynamicForms.js
@@ -43,7 +43,7 @@ const DynamicFormsCode = () => {
                   { formApi.values.siblings && formApi.values.siblings.map( ( sibling, i ) => (
                     <div key={\`sibling\${i}\`}>
                       <label htmlFor={\`sibling-name-\${i}\`}>Name</label>
-                      <Text field={['siblings', i]} id={\`sibling-name-\${i}\`} />
+                      <Text field={['siblings', i]} id={\`sibling-name-$\{i}\`} validateOnMount validate={value => ({ error: !value ? \`Required-$\{i}\` : null })} />
                       <button
                         onClick={() => formApi.removeValue('siblings', i)}
                         type="button"
@@ -105,7 +105,7 @@ class DynamicForms extends Component {
                 { formApi.values.siblings && formApi.values.siblings.map( ( sibling, i ) => (
                   <div key={`sibling${i}`}>
                     <label htmlFor={`sibling-name-${i}`}>Name</label>
-                    <Text field={['siblings', i]} id={`sibling-name-${i}`} />
+                    <Text field={['siblings', i]} id={`sibling-name-${i}`} validateOnMount validate={value => ({ error: !value ? `Required-${i}` : null })} />
                     <button
                       onClick={() => formApi.removeValue('siblings', i)}
                       type="button"
@@ -120,6 +120,7 @@ class DynamicForms extends Component {
               <Data title="Submission attempts" reference="formApi.submits" data={formApi.submits} />
               <Data title="Submitted" reference="formApi.submitted" data={formApi.submitted} />
               <Data title="Submitted values" reference="onSubmit={submittedValues => this.setState( { submittedValues } )}" data={this.state.submittedValues} />
+              <Data title="Errors" reference="formApi.errors" data={formApi.errors} />
             </div>
           )}
         </Form>

--- a/src/components/Field.js
+++ b/src/components/Field.js
@@ -5,11 +5,17 @@ import Utils from '../utils'
 
 class Field extends React.Component {
   componentWillMount () {
-    const { defaultValue } = this.props
+    const { defaultValue, validateOnMount, field } = this.props
     this.buildApi(this.props)
 
     if (typeof defaultValue !== 'undefined' && typeof this.getFieldValues().value === 'undefined') {
       this.fieldApi.setValue(defaultValue)
+    }
+
+    if (validateOnMount) {
+      this.fieldApi.validate(field)
+      this.fieldApi.preValidate(field)
+      this.fieldApi.asyncValidate(field)
     }
   }
 
@@ -69,6 +75,10 @@ class Field extends React.Component {
   }
 
   componentWillUnmount () {
+    const { field, validateOnMount } = this.props
+    if (validateOnMount) {
+      this.context.formApi.clearError(field)
+    }
     this.context.formApi.deregister(this.node)
   }
 
@@ -134,6 +144,7 @@ class Field extends React.Component {
       validate,
       asyncValidate,
       validateOnSubmit,
+      validateOnMount,
       ...rest
     } = this.props
 
@@ -171,11 +182,13 @@ Field.contextTypes = {
 }
 
 Field.propTypes = {
-  field: PropTypes.oneOfType([PropTypes.string, PropTypes.array])
+  field: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
+  validateOnMount: PropTypes.bool
 }
 
 Field.defaultProps = {
-  pure: true
+  pure: true,
+  validateOnMount: false
 }
 
 export default Field

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -108,7 +108,8 @@ class Form extends Component {
       validate: this.validate,
       preValidate: this.preValidate,
       getFullField: this.getFullField,
-      getNodeByField: this.getNodeByField
+      getNodeByField: this.getNodeByField,
+      clearError: this.clearError,
     }
   }
 
@@ -401,6 +402,10 @@ class Form extends Component {
 
   clearAll = () => {
     this.props.dispatch(actions.clearAll())
+  }
+
+  clearError = field => {
+    this.props.dispatch(actions.clearError({ field }))
   }
 
   preSubmit = values => {

--- a/src/redux/BuildReducer.js
+++ b/src/redux/BuildReducer.js
@@ -19,7 +19,8 @@ import {
   VALIDATION_SUCCESS,
   SET_ASYNC_ERROR,
   SET_ASYNC_WARNING,
-  SET_ASYNC_SUCCESS
+  SET_ASYNC_SUCCESS,
+  SET_ALL_ERRORS,
 } from './actions'
 
 import Utils from '../utils'
@@ -226,6 +227,11 @@ const reset = (state, { payload: { field = '__root' } }) => {
   }
 }
 
+const replaceErrors = (state, { payload: { errors } }) => ({
+  ...state,
+  errors,
+})
+
 //
 
 export default function BuildReducer ({ defaultValues = {}, values = {} } = {}) {
@@ -281,6 +287,8 @@ export default function BuildReducer ({ defaultValues = {}, values = {} } = {}) 
         return doneValidatingField(state, action)
       case VALIDATING_FIELD:
         return validatingField(state, action)
+      case SET_ALL_ERRORS:
+        return replaceErrors(state, action)
       default:
         return state
     }

--- a/src/redux/actions.js
+++ b/src/redux/actions.js
@@ -25,6 +25,7 @@ export const VALIDATING_FIELD = 'VALIDATING_FIELD'
 export const DONE_VALIDATING_FIELD = 'DONE_VALIDATING_FIELD'
 export const VALIDATION_FAILURE = 'VALIDATION_FAILURE'
 export const VALIDATION_SUCCESS = 'VALIDATION_SUCCESS'
+export const SET_ALL_ERRORS = 'SET_ALL_ERRORS'
 
 export const setFormState = makeAction(SET_FORM_STATE)
 export const setValue = makeAction(SET_VALUE)
@@ -49,6 +50,7 @@ export const validatingField = makeAction(VALIDATING_FIELD)
 export const doneValidatingField = makeAction(DONE_VALIDATING_FIELD)
 export const validationFailure = makeAction(VALIDATION_FAILURE)
 export const validationSuccess = makeAction(VALIDATION_SUCCESS)
+export const setAllErrors = makeAction(SET_ALL_ERRORS)
 
 export function preValidate ({ field, validator }) {
   return (dispatch, getState) => {
@@ -115,6 +117,13 @@ export function validate ({ field, validator }) {
     recurse(result, field)
 
     return Utils.cleanError(result, { removeSuccess: true })
+  }
+}
+
+export function clearError ({ field }) {
+  return (dispatch, getState) => {
+    const newErrors = Utils.removeError(field, getState().errors)
+    dispatch(setAllErrors({ errors: newErrors }))
   }
 }
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -9,7 +9,8 @@ export default {
   noop,
   makePathArray,
   mapObject,
-  cleanError
+  cleanError,
+  removeError
 }
 
 function isArray (a) {
@@ -201,4 +202,37 @@ function cleanError (obj, { removeSuccess } = {}) {
     }
   }
   return obj
+}
+
+function removeError (field = undefined, errors = undefined) {
+  if (!field || !errors) {
+    return errors
+  }
+  // field is array
+  if (isArray(field)) {
+    const fieldName = field[0]
+    const fieldIndex = field[1]
+    // check if field and error exist in errors
+    if (!errors[fieldName] || errors[fieldName].length < fieldIndex) {
+      return errors
+    }
+    // remove key if the only field
+    if (errors[fieldName].length - 1 === 0) {
+      delete errors[fieldName]
+      return { ...errors }
+    }
+    // remove field error
+    return { ...errors,
+      [fieldName]: [
+        ...errors[fieldName].slice(0, fieldIndex),
+        ...errors[fieldName].slice(fieldIndex + 1)
+      ] }
+  }
+  // remove simple field error
+  if (errors[field]) {
+    delete errors[field]
+    return { ...errors }
+  }
+  // return original errors
+  return errors
 }


### PR DESCRIPTION
Recently, we started moving our project to React and we want to use this library to build our forms. We have a lot of dynamic forms and most of the inputs have "validate on mount" property, which is basically the same as  `validateOnMount` on the Form component. 

I added the `validateOnMount` property to generic `Field` component. 

I have also encountered a situation, when errors will remain in state, after some `Field` is removed from DOM. I've added simple action, that will remove the error from form state (similar to #268).

It would be nice if we could get this in :wink: 