### PR TITLE
Add dirty/pristine state to form fields

### DIFF
--- a/src/components/FieldApi.js
+++ b/src/components/FieldApi.js
@@ -26,7 +26,8 @@ class FieldApi extends React.Component {
         touched: formApi.getTouched(fullField),
         error: formApi.getError(fullField),
         warning: formApi.getWarning(fullField),
-        success: formApi.getSuccess(fullField)
+        success: formApi.getSuccess(fullField),
+        dirty: formApi.getDirty(fullField)
       }
       : {}
 

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -111,7 +111,8 @@ class Form extends Component {
       getNodeByField: this.getNodeByField,
       setDirty: this.setDirty,
       setAllDirty: this.setAllDirty,
-      getDirty: this.getDirty
+      getDirty: this.getDirty,
+      getPristine: this.getPristine
     }
   }
 
@@ -199,6 +200,7 @@ class Form extends Component {
 
   setValue = (field, value) => {
     this.props.dispatch(actions.setValue({ field, value }))
+    this.setDirty(field)
     // Validate up the tree
     this.validateUpFromNode(field)
   }
@@ -279,13 +281,15 @@ class Form extends Component {
     )
   }
 
-  setAllValues = (values = {}) =>
+  setAllValues = (values = {}) => {
     this.props.dispatch(
       actions.setAllValues({
         ...this.props.defaultValues,
         ...values
       })
     )
+    this.setAllDirty()
+  }
 
 
   setAllTouched = async () => {
@@ -335,7 +339,7 @@ class Form extends Component {
     this.props.dispatch(actions.setFormState(formState))
   }
 
-  setAllDirty  = () => {
+  setAllDirty = async () => {
     let dirty = {}
 
     await this.recurseUpAllNodes(node => {
@@ -349,7 +353,7 @@ class Form extends Component {
     this.props.dispatch(actions.setAllDirty(dirty))
   }
 
-	getTouched = field => Utils.get(this.props.formState.touched, field)
+  getTouched = field => Utils.get(this.props.formState.touched, field)
 
   getValue = field => Utils.get(this.props.formState.values, field)
 
@@ -361,7 +365,9 @@ class Form extends Component {
 
   getFullField = field => field
 
-  getDirty = field => Utils.get(this.props.formState.dirty, field);
+  getDirty = field => Utils.get(this.props.formState.dirty, field)
+
+  getPristine = () => Object.keys(this.props.formState.dirty) === 0
 
   addValue = (field, value) => {
     this.props.dispatch(

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -339,7 +339,7 @@ class Form extends Component {
     this.props.dispatch(actions.setFormState(formState))
   }
 
-  setAllDirty = async () => {
+  setAllDirty = async (value = true) => {
     let dirty = {}
 
     await this.recurseUpAllNodes(node => {
@@ -347,7 +347,7 @@ class Form extends Component {
         return
       }
       if (node.fullField) {
-        dirty = Utils.set(dirty, node.fullField, true)
+        dirty = Utils.set(dirty, node.fullField, value, true)
       }
     })
     this.props.dispatch(actions.setAllDirty(dirty))
@@ -422,10 +422,12 @@ class Form extends Component {
 
   reset = field => {
     this.props.dispatch(actions.reset({ field }))
+    this.setDirty(field, false);
   }
 
   resetAll = () => {
     this.props.dispatch(actions.resetAll())
+    this.setAllDirty(false);
   }
 
   clearAll = () => {
@@ -491,6 +493,7 @@ class Form extends Component {
       values = this.preSubmit(values)
       // Update submitted
       this.props.dispatch(actions.submitted())
+      this.setAllDirty(false);
       // If onSubmit was passed then call it
       if (this.props.onSubmit) {
         try {

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -108,7 +108,10 @@ class Form extends Component {
       validate: this.validate,
       preValidate: this.preValidate,
       getFullField: this.getFullField,
-      getNodeByField: this.getNodeByField
+      getNodeByField: this.getNodeByField,
+      setDirty: this.setDirty,
+      setAllDirty: this.setAllDirty,
+      getDirty: this.getDirty
     }
   }
 
@@ -216,6 +219,11 @@ class Form extends Component {
 
   setSuccess = (field, value) => {
     this.props.dispatch(actions.setSuccess({ field, value }))
+  }
+  setDirty = (field, value = true) => {
+    this.props.dispatch(actions.setDirty({ field, value }))
+    // Validate up the tree
+    this.validateUpFromNode(field)
   }
 
   preValidate = (field, opts = {}) => {
@@ -327,6 +335,20 @@ class Form extends Component {
     this.props.dispatch(actions.setFormState(formState))
   }
 
+  setAllDirty  = () => {
+    let dirty = {}
+
+    await this.recurseUpAllNodes(node => {
+      if (node.nested) {
+        return
+      }
+      if (node.fullField) {
+        dirty = Utils.set(dirty, node.fullField, true)
+      }
+    })
+    this.props.dispatch(actions.setAllDirty(dirty))
+  }
+
 	getTouched = field => Utils.get(this.props.formState.touched, field)
 
   getValue = field => Utils.get(this.props.formState.values, field)
@@ -338,6 +360,8 @@ class Form extends Component {
   getSuccess = field => Utils.get(this.props.formState.successes, field)
 
   getFullField = field => field
+
+  getDirty = field => Utils.get(this.props.formState.dirty, field);
 
   addValue = (field, value) => {
     this.props.dispatch(

--- a/src/redux/BuildReducer.js
+++ b/src/redux/BuildReducer.js
@@ -19,7 +19,9 @@ import {
   VALIDATION_SUCCESS,
   SET_ASYNC_ERROR,
   SET_ASYNC_WARNING,
-  SET_ASYNC_SUCCESS
+  SET_ASYNC_SUCCESS,
+  SET_DIRTY,
+  SET_ALL_DIRTY
 } from './actions'
 
 import Utils from '../utils'
@@ -39,7 +41,8 @@ const INITIAL_STATE = {
   asyncValidations: 0,
   submitted: false,
   submits: 0,
-  submitting: false
+  submitting: false,
+  dirty: {}
 }
 
 const setFormState = (state, { payload }) => ({ ...INITIAL_STATE, ...payload })
@@ -70,6 +73,19 @@ const setTouched = (state, { payload: { field, value } }) => {
 const setAllTouched = (state, { payload: touched }) => ({
   ...state,
   touched,
+})
+
+const setDirty = (state, { payload: { field, value } }) => {
+  const newDirty = Utils.set(Utils.clone(state.dirty), field, value, true)
+  return {
+    ...state,
+    dirty: newDirty
+  }
+}
+
+const setAllDirty = (state, { payload: dirty }) => ({
+  ...state,
+  dirty
 })
 
 const setError = (state, { payload: { field = '__root', value } }) => {
@@ -219,6 +235,7 @@ const reset = (state, { payload: { field = '__root' } }) => {
   Utils.set(newState.asyncErrors, field, undefined)
   Utils.set(newState.asyncWarnings, field, undefined)
   Utils.set(newState.asyncSuccesses, field, undefined)
+  Utils.set(newState.dirty, field, undefined)
 
   return {
     ...state,
@@ -281,6 +298,10 @@ export default function BuildReducer ({ defaultValues = {}, values = {} } = {}) 
         return doneValidatingField(state, action)
       case VALIDATING_FIELD:
         return validatingField(state, action)
+      case SET_DIRTY:
+        return setDirty(state, action)
+      case SET_ALL_DIRTY:
+        return setAllDirty(state, action)
       default:
         return state
     }

--- a/src/redux/actions.js
+++ b/src/redux/actions.js
@@ -25,6 +25,8 @@ export const VALIDATING_FIELD = 'VALIDATING_FIELD'
 export const DONE_VALIDATING_FIELD = 'DONE_VALIDATING_FIELD'
 export const VALIDATION_FAILURE = 'VALIDATION_FAILURE'
 export const VALIDATION_SUCCESS = 'VALIDATION_SUCCESS'
+export const SET_DIRTY = 'SET_DIRTY'
+export const SET_ALL_DIRTY = 'SET_ALL_DIRTY'
 
 export const setFormState = makeAction(SET_FORM_STATE)
 export const setValue = makeAction(SET_VALUE)
@@ -49,6 +51,8 @@ export const validatingField = makeAction(VALIDATING_FIELD)
 export const doneValidatingField = makeAction(DONE_VALIDATING_FIELD)
 export const validationFailure = makeAction(VALIDATION_FAILURE)
 export const validationSuccess = makeAction(VALIDATION_SUCCESS)
+export const setDirty = makeAction(SET_DIRTY)
+export const setAllDirty = makeAction(SET_ALL_DIRTY)
 
 export function preValidate ({ field, validator }) {
   return (dispatch, getState) => {

--- a/tests/components/Form.spec.js
+++ b/tests/components/Form.spec.js
@@ -31,6 +31,9 @@ describe('Form', () => {
     expect(api).to.have.own.property('swapValues')
     expect(api).to.have.own.property('removeValue')
     expect(api).to.have.own.property('addValue')
+    expect(api).to.have.own.property('setDirty')
+    expect(api).to.have.own.property('setAllDirty')
+    expect(api).to.have.own.property('getDirty')
   }
 
   const checkFormState = state => {
@@ -41,7 +44,8 @@ describe('Form', () => {
       asyncValidations: 0,
       submitted: false,
       submits: 0,
-      submitting: false
+      submitting: false,
+      dirty: {}
     }
     expect(JSON.stringify(state)).to.deep.equal(JSON.stringify(formState))
   }
@@ -54,7 +58,8 @@ describe('Form', () => {
       submits: 0,
       submitting: false,
       validationFailures: 0,
-      asyncValidations: 0
+      asyncValidations: 0,
+      dirty: {}
     }
     return Object.assign({}, defaultState, state)
   }
@@ -312,7 +317,7 @@ describe('Form', () => {
     }
     mount(<Form getApi={setApi}>{() => <Text field="greeting" />}</Form>)
     api.setValue('greeting', 'hello')
-    expect(api.getFormState()).to.deep.equal(getState({ values: { greeting: 'hello' } }))
+    expect(api.getFormState()).to.deep.equal(getState({ values: { greeting: 'hello' }, dirty: { greeting: true} }))
   })
 
   it('setError should set an error', () => {
@@ -482,7 +487,8 @@ describe('Form', () => {
       input.simulate('change', { target: { value: 'Foo' } })
       expect(api.getFormState()).to.deep.equal(
         getState({
-          values: { greeting: 'Foo' }
+          values: { greeting: 'Foo' },
+          dirty: { greeting: true }
         })
       )
       const button = wrapper.find('button')

--- a/tests/components/Form.spec.js
+++ b/tests/components/Form.spec.js
@@ -34,6 +34,7 @@ describe('Form', () => {
     expect(api).to.have.own.property('setDirty')
     expect(api).to.have.own.property('setAllDirty')
     expect(api).to.have.own.property('getDirty')
+    expect(api).to.have.own.property('getPristine')
   }
 
   const checkFormState = state => {

--- a/tests/redux/ReducerBuilder.spec.js
+++ b/tests/redux/ReducerBuilder.spec.js
@@ -31,7 +31,9 @@ const {
   REMOVE_ASYNC_ERROR,
   REMOVE_ASYNC_WARNING,
   REMOVE_ASYNC_SUCCESS,
-  CLEAR_ALL
+  CLEAR_ALL,
+  SET_DIRTY,
+  SET_ALL_DIRTY
 } = actions
 
 describe('BuildReducer', () => {
@@ -56,7 +58,8 @@ describe('BuildReducer', () => {
         validating: undefined,
         validationFailed: undefined,
         validationFailures: 0,
-        asyncValidations: 0
+        asyncValidations: 0,
+        dirty: {}
       }
       return Object.assign({}, defaultState, state)
     }
@@ -205,6 +208,9 @@ describe('BuildReducer', () => {
         },
         touched: {
           foo: undefined
+        },
+        dirty: {
+          foo: undefined
         }
       })
       const action1 = actions.setValue({ field: 'foo', value: 'bar' })
@@ -322,6 +328,20 @@ describe('BuildReducer', () => {
       const finalState = actionsToReduce.reduce(reducer, undefined)
 
       expect(finalState).to.deep.equal(expectedFinalState)
+    })
+    it(`handles ${SET_DIRTY}`, () => {
+      const reducer = BuildReducer()
+      const expectedState = getState({ dirty: { foo: true } })
+      const action = actions.setDirty({ field: 'foo', value: true })
+      const nextState = reducer(undefined, action)
+      expect(nextState).to.deep.equal(expectedState)
+    })
+    it(`handles ${SET_ALL_DIRTY}`, () => {
+      const reducer = BuildReducer()
+      const expectedState = getState({ dirty: { foo: true, baz: true } })
+      const action = actions.setAllDirty({ foo: true, baz: true })
+      const nextState = reducer(getState({ dirty: { foo: false, baz: false } }), action)
+      expect(nextState).to.deep.equal(expectedState)
     })
   })
 })


### PR DESCRIPTION
I was looking for a way to show/enable a save button only if the user had actually modified a field instead of tabbing to the field. Most of the changes are the same as the code in `setTouched` to make sure all the appropriate validation happens